### PR TITLE
[Inode dev] Fixed r/w file to disk and reload from disk

### DIFF
--- a/include/inode_entry.h
+++ b/include/inode_entry.h
@@ -73,6 +73,8 @@ int dump_inode_bitmap ();
 
 int dump_inode (inode *inode_entry);
 
+int dump_block (int block_id, void *address, size_t len);
+
 /*
  * Inode Function prototypes(External)
  */

--- a/include/inode_entry.h
+++ b/include/inode_entry.h
@@ -36,6 +36,7 @@ typedef struct inode_entry {
     short name_len;
     int num[15];
     char filename[32];
+    char empty[8]; //make size to 128byte
 } inode;
 
 

--- a/lib/block.c
+++ b/lib/block.c
@@ -363,7 +363,7 @@ int read_block(const int block_ID, void *block)
             return -4;
         }
 
-        //memcpy(block, tmp, BLOCK_SIZE);
+        memcpy(block, tmp, BLOCK_SIZE);
 
         close(file_state);
     } else {

--- a/lib/block.c
+++ b/lib/block.c
@@ -54,6 +54,23 @@ int update_super_block(int fd)
 }
 
 /*
+ * Load super block's block bitmap
+ * ONLY can be used by block.c functions !!
+ */
+int load_super_block(int fd)
+{
+    if(lseek(fd, strlen(FILE_SYSTEM_HEADER), SEEK_SET) < 0) {
+        LOG_WARN("lseek fail, detail: %s\n", strerror(errno));
+        return 0;
+    }
+    if(read(fd, block_map, NUMBER_OF_BLOCKS/SIZEOF_BYTE) != NUMBER_OF_BLOCKS/SIZEOF_BYTE) {
+        LOG_WARN("Fail to write, detail: %s\n", strerror(errno));
+        return 0;
+    }
+    return 1;
+}
+
+/*
  * Assign block for user
  * 	return value >=1 : assign successfully
  * 	return value = 0 : no valid block
@@ -157,6 +174,13 @@ int load_filesystem(const char *path)
             }
         }
 
+        memset(block_map, 0, NUMBER_OF_BLOCKS/SIZEOF_BYTE);//clear the block map to all zero
+
+        load_super_block(file_state);
+        uint8_t i;
+        for(i = 64; i < 70; i++) {
+            LOG_DEBUG("Bitmap %d: %x\n", i, block_map[i]);
+        }
         snprintf(file_system_path, 100, "%s", path);
         close(file_state);
         return 0;
@@ -222,14 +246,18 @@ int read_super_block(void *block, int block_output_length)
 
         if(block_output_length < SUPER_BLOCK_SIZE) {
             LOG_DEBUG("block_input_length < BLOCK_SIZE\n");
-            if(read(file_state, block, block_output_length) != block_output_length) {
-                LOG_WARN("Fail to write, detail: %s\n", strerror(errno));
-                return -4;
-            }
-            byte_read = block_output_length;
+
         }
+
+        if(read(file_state, block, block_output_length) != block_output_length) {
+            LOG_WARN("Fail to write, detail: %s\n", strerror(errno));
+            return -4;
+        }
+        byte_read = block_output_length;
+
         close(file_state);
     } else {
+        LOG_WARN("No valid file_state\n");
         return -1;
     }
 

--- a/lib/directory.c
+++ b/lib/directory.c
@@ -47,7 +47,7 @@ char* dir_init()
 
         memset(tmp, 0, sizeof(inode));
         if (i == 1) {
-            dump_inode(tmp);
+            // dump_inode(tmp);
         }
         tmp->inode_id = i;
         result = query_inode(tmp);

--- a/lib/file.c
+++ b/lib/file.c
@@ -17,7 +17,8 @@ int read_file_by_path(const char *path, void **buf)
         return -1;
     }
 
-    int file_size = file_inode->filesize;
+    // add one byte for '\0'
+    int file_size = file_inode->filesize + 1;
     void *read_buf = (void*)malloc( file_size );
     int ret = read_file ( file_inode, read_buf );
 

--- a/lib/file.c
+++ b/lib/file.c
@@ -116,15 +116,16 @@ int delete_file_by_path(const char *path)
         return -2;
     }
 
-    int ret = delete_inode_from_table(file_inode);
-    if(ret<0) {
-        printf("fail:delete_inode_from_table(...).\n");
-        return -3;
-    }
-    ret = delete_file ( file_inode );
+    int ret = delete_file ( file_inode );
     if(ret<0) {
         printf("fail:delete_file(...).\n");
         return -4;
+    }
+
+    ret = delete_inode_from_table(file_inode);
+    if(ret<0) {
+        printf("fail:delete_inode_from_table(...).\n");
+        return -3;
     }
 
     return 0;

--- a/lib/file.c
+++ b/lib/file.c
@@ -79,7 +79,7 @@ int write_file_by_path(const char *path, void *buf, int size)
     void *write_buf = (void*)malloc( size );
     strncpy( (char*)write_buf, (const char*)buf, size );
     //printf("write:%s\n", (char*)write_buf);
-    
+
     // write_file needs filesize
     time_t cur_time;
     time (&cur_time);
@@ -90,7 +90,7 @@ int write_file_by_path(const char *path, void *buf, int size)
     if(ret<0) {
         return ret;
     }
-    
+
     // lower layer will save inode, save or not is OK
     // update_inode ( file_inode );
 

--- a/lib/file.c
+++ b/lib/file.c
@@ -78,17 +78,20 @@ int write_file_by_path(const char *path, void *buf, int size)
     void *write_buf = (void*)malloc( size );
     strncpy( (char*)write_buf, (const char*)buf, size );
     //printf("write:%s\n", (char*)write_buf);
+    
+    // write_file needs filesize
+    time_t cur_time;
+    time (&cur_time);
+    file_inode->filesize = size;
+    file_inode->timestamp = cur_time;
 
     int ret = write_file ( file_inode, write_buf );
     if(ret<0) {
         return ret;
     }
-
-    time_t cur_time;
-    time (&cur_time);
-    file_inode->filesize = size;
-    file_inode->timestamp = cur_time;
-    update_inode ( file_inode );
+    
+    // lower layer will save inode, save or not is OK
+    // update_inode ( file_inode );
 
     free( write_buf );
     return 0;

--- a/lib/inode_entry.c
+++ b/lib/inode_entry.c
@@ -105,7 +105,7 @@ int dump_inode (inode *inode_entry)
 int dump_block (int block_id, void *address, size_t len)
 {
     int i;
-    printf("NO.%d block is :", block_id);
+    printf("NO.%d block, Length %d :\n", block_id, len);
     for(i = 0; i < len; i++)
     {
         char *c_buf = (char*)address+i;
@@ -184,7 +184,7 @@ int update_inode (inode *inode_entry)
 
     LOG_DEBUG("Return: %d\n", ret);
 
-    // dump_inode(inode_entry);
+    dump_inode(inode_entry);
 
     return 0;
 }
@@ -322,7 +322,9 @@ int read_file (inode *inode_entry, void* file)
 
     while(next_block_id != 0) {
         // load block
-        read_block(next_block_id, &file_buffer);
+        read_block(next_block_id, file_buffer);
+
+        dump_block(inode_entry->num[i], file_buffer, BLOCK_SIZE);
 
         // load next block
         if(i+1 < SINGLE_INDIRECT_BLOCK_SEQ) {
@@ -369,7 +371,6 @@ int write_file (inode *inode_entry, void* file)
     char file_buffer[BLOCK_SIZE];
     int block_id_buf;
     int block_data_len;
-
 
     // load indirect block_num
     if(inode_entry->num[SINGLE_INDIRECT_BLOCK_SEQ] != 0) {
@@ -418,16 +419,17 @@ int write_file (inode *inode_entry, void* file)
 
         for(; i < inode_entry->filesize / BLOCK_SIZE + 1; i++) {
             // determine the length of block and copy block into buffer
-            if(i == inode_entry->filesize / BLOCK_SIZE + 1) { // last block of file
+            if(i+1 == inode_entry->filesize / BLOCK_SIZE + 1) { // last block of file
                 block_data_len = inode_entry->filesize % BLOCK_SIZE;
+                //LOG_DEBUG("Block_num increase - Write Blocks. filesize is %d. block_data_len is %d", inode_entry->filesize, block_data_len);
             } else {
                 block_data_len = BLOCK_SIZE;
             }
 
             memcpy(file_buffer,file + i*BLOCK_SIZE, block_data_len);
 
-            dump_block(block_id_buf, (void *)&file_buffer, block_data_len);
             write_block(&block_id_buf, &file_buffer, block_data_len);
+            dump_block(block_id_buf, (void *)&file_buffer, block_data_len);
 
             // direct or indirect block
             if(i < SINGLE_INDIRECT_BLOCK_SEQ) {

--- a/lib/inode_entry.c
+++ b/lib/inode_entry.c
@@ -102,6 +102,18 @@ int dump_inode (inode *inode_entry)
     return 0;
 }
 
+int dump_block (int block_id, void *address, size_t len)
+{
+    int i;
+    printf("NO.%d block is :", block_id);
+    for(i = 0; i < len; i++)
+    {
+        char *c_buf = (char*)address+i;
+        printf("%c", *c_buf);
+    }
+    printf("\n");
+}
+
 
 /*
  * inode extrnal operation
@@ -172,7 +184,7 @@ int update_inode (inode *inode_entry)
 
     LOG_DEBUG("Return: %d\n", ret);
 
-    dump_inode(inode_entry);
+    // dump_inode(inode_entry);
 
     return 0;
 }
@@ -199,7 +211,7 @@ int create_inode (inode *inode_entry)
             target_id = i;
             set_inode_bitmap(target_id);
             inode_entry->inode_id = target_id;
-            dump_inode_bitmap();
+            // dump_inode_bitmap();
             break;
         } else {
             i++;
@@ -393,8 +405,10 @@ int write_file (inode *inode_entry, void* file)
         for(i = 0; i < block_inuse; i++) {
             memcpy(file_buffer, file + i*BLOCK_SIZE, BLOCK_SIZE);
             if(i < SINGLE_INDIRECT_BLOCK_SEQ) { //direct block
+                dump_block(inode_entry->num[i], (void *)&file_buffer, BLOCK_SIZE);
                 modify_block(inode_entry->num[i], &file_buffer, BLOCK_SIZE);
             } else { //indirect block
+                dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, BLOCK_SIZE);
                 modify_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], &file_buffer, BLOCK_SIZE);
             }
         }
@@ -411,6 +425,8 @@ int write_file (inode *inode_entry, void* file)
             }
 
             memcpy(file_buffer,file + i*BLOCK_SIZE, block_data_len);
+
+            dump_block(block_id_buf, (void *)&file_buffer, block_data_len);
             write_block(&block_id_buf, &file_buffer, block_data_len);
 
             // direct or indirect block
@@ -452,8 +468,10 @@ int write_file (inode *inode_entry, void* file)
 
             memcpy(file_buffer, file + i*BLOCK_SIZE, block_data_len);
             if(i < SINGLE_INDIRECT_BLOCK_SEQ) { //direct block
+                dump_block(inode_entry->num[i], (void *)&file_buffer, block_data_len);
                 modify_block(inode_entry->num[i], &file_buffer, block_data_len);
             } else { //indirect block
+                dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, block_data_len);
                 modify_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], &file_buffer, block_data_len);
             }
         }
@@ -483,8 +501,10 @@ int write_file (inode *inode_entry, void* file)
             memcpy(file_buffer, file + i*BLOCK_SIZE, block_data_len);
 
             if(i < SINGLE_INDIRECT_BLOCK_SEQ) { //direct block
+                dump_block(inode_entry->num[i], (void *)&file_buffer, block_data_len);
                 modify_block(inode_entry->num[i], &file_buffer, block_data_len);
             } else { //indirect block
+                dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, block_data_len);
                 modify_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], &file_buffer, block_data_len);
             }
         }

--- a/lib/inode_entry.c
+++ b/lib/inode_entry.c
@@ -192,7 +192,7 @@ int update_inode (inode *inode_entry)
 
     LOG_DEBUG("Return: %d\n", ret);
 
-    dump_inode(inode_entry);
+    //dump_inode(inode_entry);
 
     return 0;
 }
@@ -315,6 +315,13 @@ int read_file (inode *inode_entry, void* file)
     int read_block_return;
     int next_block_id;
     char file_buffer[BLOCK_SIZE];
+
+    if(inode_entry->filesize == 0)
+    {
+        file_buffer[0] = '\0';
+        memmove(file + inode_entry->filesize, &file_buffer[0], 1 );
+        return 0;
+    }
 
     // load indirect block_num
     if(inode_entry->num[SINGLE_INDIRECT_BLOCK_SEQ - 1] != 0) {

--- a/lib/inode_entry.c
+++ b/lib/inode_entry.c
@@ -107,8 +107,7 @@ int dump_block (int block_id, void *address, size_t len)
 {
     int i;
     printf("NO.%d block, Length %d :\n", block_id, len);
-    for(i = 0; i < len; i++)
-    {
+    for(i = 0; i < len; i++) {
         char *c_buf = (char*)address+i;
         printf("%c", *c_buf);
     }
@@ -141,11 +140,9 @@ int query_inode (inode *inode_entry)
     if(!query_inode_bitmap(inode_entry->inode_id)) {
         // LOG_ERROR("inode_id:%d doesn't exist in inode bitmap\n", inode_entry->inode_id);
         return -1;
-    }
-    else
-    {
+    } else {
         LOG_DEBUG("inode_id:%d HIT !!!\n", inode_entry->inode_id);
-        
+
     }
 
     read_block(inode_block_id, &inode_group);
@@ -168,7 +165,7 @@ int query_inode (inode *inode_entry)
 
 int update_inode (inode *inode_entry)
 {
-    
+
     int ret;
 
     // get block id
@@ -316,8 +313,7 @@ int read_file (inode *inode_entry, void* file)
     int next_block_id;
     char file_buffer[BLOCK_SIZE];
 
-    if(inode_entry->filesize == 0)
-    {
+    if(inode_entry->filesize == 0) {
         file_buffer[0] = '\0';
         memmove(file + inode_entry->filesize, &file_buffer[0], 1 );
         return 0;
@@ -377,9 +373,9 @@ int read_file (inode *inode_entry, void* file)
 
     }
     LOG_DEBUG("Load block num: %d, File Size: %d\n", i, inode_entry->filesize);
-    
-    
-    
+
+
+
 
     // return
     return 0;
@@ -469,8 +465,7 @@ int write_file (inode *inode_entry, void* file)
         if(inode_entry->num[SINGLE_INDIRECT_BLOCK_SEQ] != 0) {
             modify_block(inode_entry->num[12], &single_indirect_block, (int)(sizeof(single_indirect_block)));
         } else {
-            if(inode_entry->filesize / BLOCK_SIZE >= SINGLE_INDIRECT_BLOCK_SEQ)
-            {
+            if(inode_entry->filesize / BLOCK_SIZE >= SINGLE_INDIRECT_BLOCK_SEQ) {
                 write_block(&block_id_buf, &single_indirect_block, (int)(sizeof(single_indirect_block)));
                 inode_entry->num[SINGLE_INDIRECT_BLOCK_SEQ] = block_id_buf;
             }

--- a/lib/inode_entry.c
+++ b/lib/inode_entry.c
@@ -85,20 +85,20 @@ int dump_inode (inode *inode_entry)
 {
     int i;
 
-    printf("------ Dump inode_entry ------\n");
-    printf("inode_id: %d\n", inode_entry->inode_id);
-    printf("filesize: %d\n", inode_entry->filesize);
-    printf("uid: %d\n", inode_entry->uid);
-    printf("gid: %d\n", inode_entry->gid);
-    printf("filemode: %d\n", inode_entry->filemode);
-    printf("timestamp: %d\n", inode_entry->timestamp);
-    printf("file_type: %d\n", inode_entry->file_type);
-    printf("name_len: %d\n", inode_entry->name_len);
+    LOG_DEBUG("------ Dump inode_entry ------\n");
+    LOG_DEBUG("inode_id: %d\n", inode_entry->inode_id);
+    LOG_DEBUG("filesize: %d\n", inode_entry->filesize);
+    LOG_DEBUG("uid: %d\n", inode_entry->uid);
+    LOG_DEBUG("gid: %d\n", inode_entry->gid);
+    LOG_DEBUG("filemode: %d\n", inode_entry->filemode);
+    LOG_DEBUG("timestamp: %d\n", inode_entry->timestamp);
+    LOG_DEBUG("file_type: %d\n", inode_entry->file_type);
+    LOG_DEBUG("name_len: %d\n", inode_entry->name_len);
     for (i = 0; i < 15; i++) {
-        printf("num[%d]: %d\n", i, inode_entry->num[i]);
+        LOG_DEBUG("num[%d]: %d\n", i, inode_entry->num[i]);
     }
-    printf("filename: %s\n", inode_entry->filename);
-    printf("-----------------------------\n");
+    LOG_DEBUG("filename: %s\n", inode_entry->filename);
+    LOG_DEBUG("-----------------------------\n");
 
     return 0;
 }
@@ -428,10 +428,10 @@ int write_file (inode *inode_entry, void* file)
         for(i = 0; i < block_inuse; i++) {
             memcpy(file_buffer, file + i*BLOCK_SIZE, BLOCK_SIZE);
             if(i < SINGLE_INDIRECT_BLOCK_SEQ) { //direct block
-                dump_block(inode_entry->num[i], (void *)&file_buffer, BLOCK_SIZE);
+                // dump_block(inode_entry->num[i], (void *)&file_buffer, BLOCK_SIZE);
                 modify_block(inode_entry->num[i], &file_buffer, BLOCK_SIZE);
             } else { //indirect block
-                dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, BLOCK_SIZE);
+                // dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, BLOCK_SIZE);
                 modify_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], &file_buffer, BLOCK_SIZE);
             }
         }
@@ -451,7 +451,7 @@ int write_file (inode *inode_entry, void* file)
             memcpy(file_buffer,file + i*BLOCK_SIZE, block_data_len);
 
             write_block(&block_id_buf, &file_buffer, block_data_len);
-            dump_block(block_id_buf, (void *)&file_buffer, block_data_len);
+            // dump_block(block_id_buf, (void *)&file_buffer, block_data_len);
 
             // direct or indirect block
             if(i < SINGLE_INDIRECT_BLOCK_SEQ) {
@@ -496,10 +496,10 @@ int write_file (inode *inode_entry, void* file)
 
             memcpy(file_buffer, file + i*BLOCK_SIZE, block_data_len);
             if(i < SINGLE_INDIRECT_BLOCK_SEQ) { //direct block
-                dump_block(inode_entry->num[i], (void *)&file_buffer, block_data_len);
+                // dump_block(inode_entry->num[i], (void *)&file_buffer, block_data_len);
                 modify_block(inode_entry->num[i], &file_buffer, block_data_len);
             } else { //indirect block
-                dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, block_data_len);
+                // dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, block_data_len);
                 modify_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], &file_buffer, block_data_len);
             }
         }
@@ -531,10 +531,10 @@ int write_file (inode *inode_entry, void* file)
             memcpy(file_buffer, file + i*BLOCK_SIZE, block_data_len);
 
             if(i < SINGLE_INDIRECT_BLOCK_SEQ) { //direct block
-                dump_block(inode_entry->num[i], (void *)&file_buffer, block_data_len);
+                // dump_block(inode_entry->num[i], (void *)&file_buffer, block_data_len);
                 modify_block(inode_entry->num[i], &file_buffer, block_data_len);
             } else { //indirect block
-                dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, block_data_len);
+                // dump_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], (void *)&file_buffer, block_data_len);
                 modify_block(single_indirect_block.num12[i - SINGLE_INDIRECT_BLOCK_SEQ], &file_buffer, block_data_len);
             }
         }

--- a/test/test_inode/test_inode.cpp
+++ b/test/test_inode/test_inode.cpp
@@ -6,6 +6,10 @@ int main ()
     create_filesystem("./filesystem.txt");
 
     init_superblock();
+
+    char test_string[20] = "MooTanO~~~";
+    int test_string_len = 10;
+
     //dump_inode_bitmap();
     
     //char test_file[100] = "The quick brown fox jumps over the lazy dog\0";
@@ -49,10 +53,11 @@ int main ()
     */
 
     // ------ create inode test ------
-    printf("------ create inode test ------\n");
-    inode_entry test_inode_entry_1;
-    init_inode(&test_inode_entry_1, sizeof(test_inode_entry_1));
-    create_inode(&test_inode_entry_1);
+    // printf("------ create inode test ------\n");
+    // inode_entry test_inode_entry_1;
+    // init_inode(&test_inode_entry_1, sizeof(test_inode_entry_1));
+    // test_inode_entry_1.filesize = 87;
+    // create_inode(&test_inode_entry_1);
     //dump_inode(&test_inode_entry_1);
 
     // inode_entry test_inode_entry_2;
@@ -64,6 +69,13 @@ int main ()
     // printf("------ delete inode test ------\n");
     // printf("------------------------\n\n");
 
+    // ------ query test ------
+    // printf("------ query test ------\n");
+    // inode_entry test_inode_entry_3;
+    // test_inode_entry_3.inode_id = 0;
+    // query_inode(&test_inode_entry_3);
+    // dump_inode(&test_inode_entry_3);
+
     // ------ Write Test ------
     // test_inode_entry_1.filesize = int(sizeof(test_bigfile));
     // write_file(&test_inode_entry_1, test_bigfile);
@@ -74,6 +86,9 @@ int main ()
 
     // delete_file(&test_inode_entry_1);
     // dump_inode_bitmap();
+
+    // ------ Test dump_block ------
+    // dump_block(87, test_string, test_string_len);
 
     return 0;
 }


### PR DESCRIPTION
:tada: 
changes  
1. Append '\0' to the final of file when using read_file. Easier to print at upper layer
2. delete_file_by_path: delete_inode needs to know which block need to be delete(record in inode). So I modify the order (delete file and inode in disk, then delete inode in memory)
3. read_file_by_path: Because write_file needs filesize, I modify the instruct order in the function
4. fix bug the block didn't load superblock to memory when load_filesystem